### PR TITLE
Fix: Parsing type argument in Vault.Retrieve handler

### DIFF
--- a/services/vault/src/retrieve.ts
+++ b/services/vault/src/retrieve.ts
@@ -28,16 +28,14 @@ export const handler = async (
   const result = await processRequest(
     async (): Promise<RetrieveVaultResponse> => {
       const request: RetrieveVaultRequest = JSON.parse(event.body);
-      const { vsk } = request;
-      let { uuid, type } = event.pathParameters;
+      const { vsk, type: requestType } = request;
+      let { uuid } = event.pathParameters;
 
       if (!uuid || uuid === '') {
         throw new ValidationError('uuid cannot be blank.');
       }
 
-      if (!type || type === '') {
-        type = 'password';
-      }
+      const type = requestType ? requestType : 'password';
 
       console.log('retrieve for', { uuid, vsk });
 

--- a/services/vault/src/types.ts
+++ b/services/vault/src/types.ts
@@ -10,6 +10,9 @@ export interface StoreVaultRequest {
 }
 
 export interface RetrieveVaultRequest {
+  // vault type
+  type: string;
+
   // Vault service key
   vsk: string;
 }


### PR DESCRIPTION
### Description
This fixes a bug with Vault retrieval handler, where it assumes `type` is part of the path params, but instead is currently being passed as the request body. This causes the vault retrieve handler to always default type to password.

[ch20462]