### PR TITLE
replaced svgs with pngs

### DIFF
--- a/services/rest/src/emails/compiledHtmls/shareInvitation.html
+++ b/services/rest/src/emails/compiledHtmls/shareInvitation.html
@@ -1,4 +1,4 @@
-<!-- FILE: ./shareInvitiation.mjml -->
+<!-- FILE: ./services/rest/src/emails/templates/shareInvitiation.mjml -->
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
@@ -124,7 +124,7 @@
                                               <tr>
                                                 <td style="width:180px;">
                                                   <a href="https://space.storage" target="_blank">
-                                                    <img height="auto" src="https://fleek-team-bucket.storage.fleek.co/space-emails/space-with-text.svg" style="border:none;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" title="" width="180" />
+                                                    <img height="auto" src="https://fleek-team-bucket.storage.fleek.co/space-with-text.png" style="border:none;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" title="" width="180" />
                                                   </a>
                                                 </td>
                                               </tr>

--- a/services/rest/src/emails/shareInvitation/index.ts
+++ b/services/rest/src/emails/shareInvitation/index.ts
@@ -11,15 +11,15 @@ const htmlTemplate = fs.readFileSync(
 );
 
 const iconTypeMapping = {
-  [FILE_TYPES.FOLDER]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Unknown.svg',
-  [FILE_TYPES.IMAGE]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Image.svg',
-  [FILE_TYPES.PDF]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/PDF.svg',
-  [FILE_TYPES.ZIP]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/ZIP.svg',
-  [FILE_TYPES.WORD]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/TextDoc.svg',
-  [FILE_TYPES.VIDEO]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Video.svg',
-  [FILE_TYPES.AUDIO]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Audio.svg',
-  [FILE_TYPES.DEFAULT]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Unknown.svg',
-  [FILE_TYPES.POWERPOINT]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Presentation.svg',
+  [FILE_TYPES.FOLDER]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Unknown.png',
+  [FILE_TYPES.IMAGE]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Image.png',
+  [FILE_TYPES.PDF]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/PDF.png',
+  [FILE_TYPES.ZIP]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/ZIP.png',
+  [FILE_TYPES.WORD]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/TextDoc.png',
+  [FILE_TYPES.VIDEO]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Video.png',
+  [FILE_TYPES.AUDIO]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Audio.png',
+  [FILE_TYPES.DEFAULT]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Unknown.png',
+  [FILE_TYPES.POWERPOINT]: 'https://fleek-team-bucket.storage.fleek.co/space-emails/file-icons/Presentation.png',
 };
 
 interface Mapping { [key: string]:string };

--- a/services/rest/src/emails/templates/shareInvitiation.mjml
+++ b/services/rest/src/emails/templates/shareInvitiation.mjml
@@ -6,7 +6,7 @@
     <mj-wrapper background-color="#151515" padding="60px">
       <mj-section>
         <mj-column padding-bottom="10px" width="100%">
-          <mj-image width="180px" href="https://space.storage" align="center" border="none" src="https://fleek-team-bucket.storage.fleek.co/space-emails/space-with-text.svg" target="_blank" title=""></mj-image>
+          <mj-image width="180px" href="https://space.storage" align="center" border="none" src="https://fleek-team-bucket.storage.fleek.co/space-with-text.png" target="_blank" title=""></mj-image>
         </mj-column>
       </mj-section>
       <mj-section border-radius="12px" background-color="transparent linear-gradient(180deg, #303030 0%, #1A1A1A 100%) 0% 0% no-repeat padding-box" text-align="center" padding="34px 0px 42px 0">


### PR DESCRIPTION
It turns out email clients do not live SVGs. Images in the email template have been replaced by PNGs.